### PR TITLE
BindingAdatper: removed adapter for setter with just one parameter; removed prefix app.

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="EntryPointsManager">
+    <list size="2">
+      <item index="0" class="java.lang.String" itemvalue="androidx.databinding.BindingAdapter" />
+      <item index="1" class="java.lang.String" itemvalue="androidx.lifecycle.OnLifecycleEvent" />
+    </list>
+  </component>
   <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -24,7 +24,7 @@ android {
     }
 
     buildFeatures {
-        dataBinding = true
+        dataBinding true
     }
 
     compileOptions {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -6,10 +6,6 @@ apply plugin: 'kotlin-kapt'
 android {
     compileSdkVersion vCompileSdk
 
-    dataBinding {
-        enabled = true
-    }
-
     defaultConfig {
         applicationId 'me.li2.android.viewsample'
         minSdkVersion vMinSdk
@@ -25,6 +21,10 @@ android {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
+    }
+
+    buildFeatures {
+        dataBinding = true
     }
 
     compileOptions {

--- a/app/src/main/java/me/li2/android/viewsample/MainActivity.kt
+++ b/app/src/main/java/me/li2/android/viewsample/MainActivity.kt
@@ -1,7 +1,7 @@
 package me.li2.android.viewsample
 
-import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
 
 class MainActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -1,6 +1,6 @@
 <resources>
     <!-- Base application theme. -->
-    <style name="AppTheme" parent="Theme.AppCompat.Light.DarkActionBar">
+    <style name="AppTheme" parent="Theme.MaterialComponents.DayNight.DarkActionBar">
         <!-- Customize your theme here. -->
         <item name="colorPrimary">@color/colorPrimary</item>
         <item name="colorPrimaryDark">@color/colorPrimaryDark</item>

--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,7 @@ allprojects {
         vTargetSdk = 29
 
         // My Libraries Dependencies
-        vLi2Common = '0.1.0'
+        vLi2Common = '0.1.7'
 
         // Android X Dependencies
         vAndroidxAppcompat = '1.1.0'
@@ -47,7 +47,7 @@ allprojects {
 
         // Rx Dependencies
         vRxAndroid = '2.1.1'
-        vRxBinding = '3.0.0-alpha2'
+        vRxBinding = '3.1.0'
         vRxKotlin = '2.3.0'
 
         // Misc

--- a/view/build.gradle
+++ b/view/build.gradle
@@ -24,7 +24,7 @@ android {
     }
 
     buildFeatures {
-        dataBinding = true
+        dataBinding true
     }
 
     compileOptions {

--- a/view/build.gradle
+++ b/view/build.gradle
@@ -23,6 +23,10 @@ android {
         }
     }
 
+    buildFeatures {
+        dataBinding = true
+    }
+
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
@@ -30,10 +34,6 @@ android {
 
     kotlinOptions {
         jvmTarget = "1.8"
-    }
-
-    dataBinding {
-        enabled = true
     }
 }
 

--- a/view/src/main/java/me/li2/android/view/button/MaterialLoadingButton.kt
+++ b/view/src/main/java/me/li2/android/view/button/MaterialLoadingButton.kt
@@ -26,7 +26,7 @@ class MaterialLoadingButton @JvmOverloads constructor(
     private var animatedDrawable: CircularAnimatedDrawable? = null
     private var originalText = ""
 
-    var isLoading = false
+    var isLoading: Boolean = false
         set(value) {
             field = value
             isClickable = !value

--- a/view/src/main/java/me/li2/android/view/button/MaterialLoadingButton.kt
+++ b/view/src/main/java/me/li2/android/view/button/MaterialLoadingButton.kt
@@ -3,9 +3,7 @@ package me.li2.android.view.button
 import android.content.Context
 import android.graphics.Canvas
 import android.util.AttributeSet
-import androidx.databinding.BindingAdapter
 import com.google.android.material.button.MaterialButton
-import me.li2.android.common.logic.orFalse
 import kotlin.math.min
 
 /**
@@ -69,11 +67,5 @@ class MaterialLoadingButton @JvmOverloads constructor(
     companion object {
         private const val SPINNER_RADIUS_PERCENT = 0.35f
         private const val SPINNER_STROKE_WIDTH = 8f
-
-        @JvmStatic
-        @BindingAdapter("isLoading")
-        fun setLoading(button: MaterialLoadingButton, isLoading: Boolean?) {
-            button.isLoading = isLoading.orFalse()
-        }
     }
 }

--- a/view/src/main/java/me/li2/android/view/button/MaterialLoadingButton.kt
+++ b/view/src/main/java/me/li2/android/view/button/MaterialLoadingButton.kt
@@ -3,7 +3,9 @@ package me.li2.android.view.button
 import android.content.Context
 import android.graphics.Canvas
 import android.util.AttributeSet
+import androidx.databinding.BindingAdapter
 import com.google.android.material.button.MaterialButton
+import me.li2.android.common.logic.orFalse
 import kotlin.math.min
 
 /**
@@ -67,5 +69,11 @@ class MaterialLoadingButton @JvmOverloads constructor(
     companion object {
         private const val SPINNER_RADIUS_PERCENT = 0.35f
         private const val SPINNER_STROKE_WIDTH = 8f
+
+        @JvmStatic
+        @BindingAdapter("isLoading")
+        fun setLoading(button: MaterialLoadingButton, isLoading: Boolean?) {
+            button.isLoading = isLoading.orFalse()
+        }
     }
 }

--- a/view/src/main/java/me/li2/android/view/image/ImageBindings.kt
+++ b/view/src/main/java/me/li2/android/view/image/ImageBindings.kt
@@ -27,11 +27,11 @@ object ImageBindings {
     @JvmStatic
     @BindingAdapter(value = [
         "android:src",
-        "app:fallbackImageUrl",
-        "app:placeHolder",
-        "app:centerCrop",
-        "app:circleCrop",
-        "app:fitCenter"
+        "fallbackImageUrl",
+        "placeHolder",
+        "centerCrop",
+        "circleCrop",
+        "fitCenter"
     ], requireAll = false)
     fun setImageUrl(view: ImageView,
                     src: String?,

--- a/view/src/main/java/me/li2/android/view/image/ImageBindings.kt
+++ b/view/src/main/java/me/li2/android/view/image/ImageBindings.kt
@@ -10,12 +10,6 @@ import me.li2.android.common.logic.orFalse
 object ImageBindings {
     @JvmStatic
     @BindingAdapter("android:src")
-    fun setImageDrawable(view: ImageView, drawable: Drawable) {
-        view.setImageDrawable(drawable)
-    }
-
-    @JvmStatic
-    @BindingAdapter("android:src")
     fun setImageResource(imageView: ImageView, resource: Int) {
         imageView.setImageResource(resource)
     }

--- a/view/src/main/java/me/li2/android/view/recyclerview/RecyclerViewBindings.kt
+++ b/view/src/main/java/me/li2/android/view/recyclerview/RecyclerViewBindings.kt
@@ -11,7 +11,7 @@ import me.li2.android.common.number.orZero
 
 object RecyclerViewBindings {
     @JvmStatic
-    @BindingAdapter("app:linearSpacing")
+    @BindingAdapter("linearSpacing")
     fun setItemLinearSpacing(recyclerView: RecyclerView, spacing: Float?) {
         val orientation = (recyclerView.layoutManager as? LinearLayoutManager)?.orientation
                 ?: RecyclerView.VERTICAL

--- a/view/src/main/java/me/li2/android/view/swiperefreshlayout/SwipeRefreshLayoutBindings.kt
+++ b/view/src/main/java/me/li2/android/view/swiperefreshlayout/SwipeRefreshLayoutBindings.kt
@@ -5,7 +5,7 @@ import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
 
 object SwipeRefreshLayoutBindings {
     @JvmStatic
-    @BindingAdapter("app:isRefreshing")
+    @BindingAdapter("isRefreshing")
     fun setSwipeRefreshLayoutRefreshing(srl: SwipeRefreshLayout, value: Boolean) {
         srl.isRefreshing = value
     }

--- a/view/src/main/java/me/li2/android/view/textview/EditTextViewBindings.kt
+++ b/view/src/main/java/me/li2/android/view/textview/EditTextViewBindings.kt
@@ -15,7 +15,7 @@ object EditTextViewBindings {
      * @see <a href="https://stackoverflow.com/questions/3406534/password-hint-font-in-android/3444882#3444882">fix hint font mess issue when set EditText inputType as textPassword.</a>
      */
     @JvmStatic
-    @BindingAdapter("app:passwordInputType")
+    @BindingAdapter("passwordInputType")
     fun setPasswordInputType(editText: EditText, enabled: Boolean?) {
         if (enabled.orFalse()) {
             editText.inputType = InputType.TYPE_TEXT_VARIATION_PASSWORD

--- a/view/src/main/java/me/li2/android/view/textview/TextViewBindings.kt
+++ b/view/src/main/java/me/li2/android/view/textview/TextViewBindings.kt
@@ -11,8 +11,10 @@ import android.widget.TextView
 import androidx.databinding.BindingAdapter
 
 object TextViewBindings {
+
+    @Suppress("DEPRECATION")
     @JvmStatic
-    @BindingAdapter("app:htmlText")
+    @BindingAdapter("htmlText")
     fun setHtmlText(textView: TextView, stringRes: String) {
         fun fromHtmlCompat(source: String): Spanned {
             return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {

--- a/view/src/main/java/me/li2/android/view/toolbar/ToolbarBindings.kt
+++ b/view/src/main/java/me/li2/android/view/toolbar/ToolbarBindings.kt
@@ -12,7 +12,7 @@ import me.li2.android.common.logic.orFalse
 
 object ToolbarBindings {
     @JvmStatic
-    @BindingAdapter("app:collapsingScrollEnabled")
+    @BindingAdapter("collapsingScrollEnabled")
     fun setCollapsingToolbarLayoutScrollEnabled(collapsingToolbarLayout: CollapsingToolbarLayout,
                                                 enabled: Boolean?) {
         val lp = collapsingToolbarLayout.layoutParams as LayoutParams

--- a/view/src/main/java/me/li2/android/view/view/LoadingOverlay.kt
+++ b/view/src/main/java/me/li2/android/view/view/LoadingOverlay.kt
@@ -6,7 +6,6 @@ import android.content.Context
 import android.util.AttributeSet
 import android.view.View
 import androidx.core.view.ViewCompat
-import androidx.databinding.BindingAdapter
 import me.li2.android.view.R
 import me.li2.android.view.toast.toast
 
@@ -34,14 +33,6 @@ class LoadingOverlayView @JvmOverloads constructor(
     override fun onClick(v: View?) {
         if (!toastText.isNullOrEmpty()) {
             context.toast(toastText.orEmpty())
-        }
-    }
-
-    companion object {
-        @JvmStatic
-        @BindingAdapter("loadingOverlayToast")
-        fun setLoadingOverlayToast(loadingOverlayView: LoadingOverlayView, toastText: String?) {
-            loadingOverlayView.toastText = toastText
         }
     }
 }

--- a/view/src/main/java/me/li2/android/view/view/LoadingOverlay.kt
+++ b/view/src/main/java/me/li2/android/view/view/LoadingOverlay.kt
@@ -1,3 +1,5 @@
+@file:Suppress("unused")
+
 package me.li2.android.view.view
 
 import android.content.Context
@@ -12,32 +14,34 @@ import me.li2.android.view.toast.toast
  * A transparent overlay view shows on top of the screen to block user touch events,
  * and toasts "Loading…" when user touches on screen.
  * - This view is useful for waiting Api, just simply update its visibility base on loading status.
- * - You might want to change the toast message by app:toastMessage="@{}"
+ * - You might want to change the toast message by app:loadingOverlayToast="@{}"
  */
 class LoadingOverlayView @JvmOverloads constructor(
         context: Context,
         attrs: AttributeSet? = null,
         defStyleAttr: Int = 0) : View(context, attrs, defStyleAttr), View.OnClickListener {
 
-    var toastMessage: String
+    var toastText: String? = null
 
     init {
         inflate(context, R.layout.loading_overlay_view, null)
         // with hard-coding elevation to make sure it CAN block all the touch events
         ViewCompat.setElevation(this, resources.getDimensionPixelSize(R.dimen.viewLib_loading_overlay_elevation) * 1.0f)
         setOnClickListener(this)
-        toastMessage = context.resources.getString(R.string.viewlib_loadingoverlay_loading)
+        toastText = context.resources.getString(R.string.viewlib_loadingoverlay_loading)
     }
 
     override fun onClick(v: View?) {
-        context.toast(toastMessage)
+        if (!toastText.isNullOrEmpty()) {
+            context.toast(toastText.orEmpty())
+        }
     }
 
     companion object {
         @JvmStatic
-        @BindingAdapter("app:toastMessage")
-        fun setUserAgentString(loadingOverlayView: LoadingOverlayView, toastMessage: String?) {
-            toastMessage?.let { loadingOverlayView.toastMessage = it }
+        @BindingAdapter("loadingOverlayToast")
+        fun setLoadingOverlayToast(loadingOverlayView: LoadingOverlayView, toastText: String?) {
+            loadingOverlayView.toastText = toastText
         }
     }
 }

--- a/view/src/main/java/me/li2/android/view/view/ViewBindings.kt
+++ b/view/src/main/java/me/li2/android/view/view/ViewBindings.kt
@@ -13,7 +13,7 @@ object ViewBindings {
     }
 
     @JvmStatic
-    @BindingAdapter("app:invisibility")
+    @BindingAdapter("invisibility")
     fun setViewInvisibility(view: View, value: Boolean?) {
         view.visibility = if (value.orFalse()) INVISIBLE else VISIBLE
     }

--- a/view/src/main/java/me/li2/android/view/webview/AdvancedWebView.kt
+++ b/view/src/main/java/me/li2/android/view/webview/AdvancedWebView.kt
@@ -17,7 +17,6 @@ import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleObserver
 import androidx.lifecycle.OnLifecycleEvent
-import kotlinx.android.synthetic.main.advanced_webview.view.*
 import me.li2.android.view.R
 import me.li2.android.view.databinding.AdvancedWebviewBinding
 
@@ -106,7 +105,7 @@ class AdvancedWebView @JvmOverloads constructor(
     }
 
     fun setUserAgentString(userAgentString: String) {
-        binding.webview.settings.userAgentString = webview.settings.userAgentString.plus(userAgentString)
+        binding.webview.settings.userAgentString += userAgentString
     }
 
     @OnLifecycleEvent(Lifecycle.Event.ON_RESUME)
@@ -131,12 +130,6 @@ class AdvancedWebView @JvmOverloads constructor(
                     url: String?,
                     additionalHttpHeaders: Map<String, String>? = null) {
             webView.loadUrl(url, additionalHttpHeaders)
-        }
-
-        @JvmStatic
-        @BindingAdapter("userAgentString")
-        fun setUserAgentString(webView: AdvancedWebView, userAgentString: String?) {
-            userAgentString?.let { webView.setUserAgentString(it) }
         }
     }
 }

--- a/view/src/main/java/me/li2/android/view/webview/AdvancedWebView.kt
+++ b/view/src/main/java/me/li2/android/view/webview/AdvancedWebView.kt
@@ -126,7 +126,7 @@ class AdvancedWebView @JvmOverloads constructor(
 
     companion object {
         @JvmStatic
-        @BindingAdapter(value = ["app:url", "app:additionalHttpHeaders"], requireAll = false)
+        @BindingAdapter(value = ["url", "additionalHttpHeaders"], requireAll = false)
         fun loadUrl(webView: AdvancedWebView,
                     url: String?,
                     additionalHttpHeaders: Map<String, String>? = null) {
@@ -134,7 +134,7 @@ class AdvancedWebView @JvmOverloads constructor(
         }
 
         @JvmStatic
-        @BindingAdapter("app:userAgentString")
+        @BindingAdapter("userAgentString")
         fun setUserAgentString(webView: AdvancedWebView, userAgentString: String?) {
             userAgentString?.let { webView.setUserAgentString(it) }
         }


### PR DESCRIPTION
- No need to create BindingAdapter for a **setter**. For example, `var isLoading: Boolean`, which jvm signature is `setLoading(Boolean)`, allows to use `app:loading="@{true}"`  directly in layout. Otherwise warning: Binding adapter AK(View, Boolean) already exists for isLoading! Overriding View.Companion#setLoading with View#setLoading. If you use `app:isLoading` in layout, error occurs: Cannot find a setter for <app:isLoading> that accepts parameter type 'java.lang.Boolean'
- No need to add `app` as the prefix in BindingAdapter, otherwise warning: Application namespace for attribute app:xxx will be ignored.